### PR TITLE
Adding SET UTF-8 to arabic

### DIFF
--- a/ar/ar.aff
+++ b/ar/ar.aff
@@ -1,3 +1,4 @@
+SET UTF-8
 FLAG	long
 AF 333
 AF TbTc # 1


### PR DESCRIPTION
Adding SET UTF-8 to arabic.
This fix solves this issue in Ubuntu
`Building PostgreSQL dictionaries from installed myspell/hunspell packages...
ERROR: no ecoding defined in /usr/share/hunspell/ar.aff, ignoring
  en_us
  fr
`