### PR TITLE
The French corrector not work properlly with É È Ê Ë when using E in the term

### DIFF
--- a/fr_FR/fr.aff
+++ b/fr_FR/fr.aff
@@ -102,7 +102,16 @@ REP ei è
 REP è ei
 REP ei ê
 REP ê ei
-REP o au
+REP e é
+REP é e
+REP e è
+REP è e
+REP e ê
+REP ê e
+REP e ë
+REP ë e
+REP o ô
+REP ô o
 REP au o
 REP o eau
 REP eau o

--- a/fr_FR/fr.aff
+++ b/fr_FR/fr.aff
@@ -44,7 +44,7 @@ MAP wW
 MAP xX
 MAP zZ
 
-REP 100
+REP 104
 REP ^Ca$ Ça
 REP ^l l'
 REP ^d d'
@@ -102,6 +102,8 @@ REP ei è
 REP è ei
 REP ei ê
 REP ê ei
+REP ^e é
+REP ^é e
 REP e é
 REP é e
 REP e è
@@ -130,6 +132,8 @@ REP ell èl
 REP èl ell
 REP t th
 REP th t
+REP ^te té
+REP ^té te
 REP ième$ e
 REP ème$ e
 REP è$ e

--- a/fr_FR/fr.aff
+++ b/fr_FR/fr.aff
@@ -112,6 +112,7 @@ REP e ë
 REP ë e
 REP o ô
 REP ô o
+REP o au
 REP au o
 REP o eau
 REP eau o

--- a/fr_FR/fr.aff
+++ b/fr_FR/fr.aff
@@ -110,6 +110,14 @@ REP e ê
 REP ê e
 REP e ë
 REP ë e
+REP ê ë
+REP ë ê
+REP é è
+REP è é
+REP é ê
+REP ê é
+REP è ê
+REP ê è
 REP o ô
 REP ô o
 REP o au

--- a/fr_FR/fr.aff
+++ b/fr_FR/fr.aff
@@ -44,7 +44,7 @@ MAP wW
 MAP xX
 MAP zZ
 
-REP 82
+REP 100
 REP ^Ca$ Ça
 REP ^l l'
 REP ^d d'

--- a/fr_FR/fr.aff
+++ b/fr_FR/fr.aff
@@ -44,7 +44,7 @@ MAP wW
 MAP xX
 MAP zZ
 
-REP 104
+REP 106
 REP ^Ca$ Ça
 REP ^l l'
 REP ^d d'
@@ -132,6 +132,8 @@ REP ell èl
 REP èl ell
 REP t th
 REP th t
+REP ^se sé
+REP ^sé se
 REP ^te té
 REP ^té te
 REP ième$ e


### PR DESCRIPTION
It seem that REP was missing this transformation.
So when you write E instead of the proper accent É È Ê Ë,
the system was not able to propose the right terms with accent,
I don't have example right now, but I know that I had many time this trouble in LibreOffice, Chrome & FireFox.
So I added it.

And I also added REP pro O & Ô !

Take care. Hope you accept this modification & improvement.