### PR TITLE
Recognise umlauts typed as -e on non-DE keyboard

### DIFF
--- a/de/de_AT_frami.aff
+++ b/de/de_AT_frami.aff
@@ -531,6 +531,15 @@ REP ch k
 REP k ch
 #REP eee ee-E
 
+MAP 7
+MAP (ss)ß
+MAP (ue)ü
+MAP (Ue)Ü
+MAP (oe)ö
+MAP (Oe)Ö
+MAP (ae)ä
+MAP (Ae)Ä
+
 
 # this one will allow "-Eltern" - Hunspell 1.1.5 bug, but CHECKSHARPS obsoletes LANG de_DE
 #LANG de_DE

--- a/de/de_CH_frami.aff
+++ b/de/de_CH_frami.aff
@@ -531,6 +531,15 @@ REP ch k
 REP k ch
 #REP eee ee-E
 
+MAP 7
+MAP (ss)ß
+MAP (ue)ü
+MAP (Ue)Ü
+MAP (oe)ö
+MAP (Oe)Ö
+MAP (ae)ä
+MAP (Ae)Ä
+
 
 # this one will allow "-Eltern" - Hunspell 1.1.5 bug, but CHECKSHARPS obsoletes LANG de_DE
 #LANG de_DE

--- a/de/de_DE_frami.aff
+++ b/de/de_DE_frami.aff
@@ -531,6 +531,15 @@ REP ch k
 REP k ch
 #REP eee ee-E
 
+MAP 7
+MAP (ss)ß
+MAP (ue)ü
+MAP (Ue)Ü
+MAP (oe)ö
+MAP (Oe)Ö
+MAP (ae)ä
+MAP (Ae)Ä
+
 
 # this one will allow "-Eltern" - Hunspell 1.1.5 bug, but CHECKSHARPS obsoletes LANG de_DE
 #LANG de_DE


### PR DESCRIPTION
This allows Germans using an English keyboard to type the Umlauts as "ue" "ae" and "oe" as is customary, and type the ß as "ss". 
Previously the spellchecker would not recognise these spellings.

As a test, try the word "Greetings"  as "Gruesse". With this fix, the correct intended spelling "Grüße" is given as a suggestion.