### PR TITLE
fix wrong REP count in mongolian .aff file

### DIFF
--- a/mn_MN/mn_MN.aff
+++ b/mn_MN/mn_MN.aff
@@ -46,7 +46,7 @@ COMPOUNDRULE (nn)*[o0,o1,o2,o3]
 COMPOUNDRULE (nn)*%?
 COMPOUNDRULE (nn)*.(nn)*%?
 
-REP 3619
+REP 3621
 REP a а
 REP c с
 REP e е


### PR DESCRIPTION
Commit d169602 broke parsing of this file by the lucene hunspell support, because now a `REP 3619` is followed by 3621 REP rules.

Fix the count to be correct.