### PR TITLE
cs_CZ thesaurus converter: guard missing type column

### DIFF
--- a/cs_CZ/thesaurus/dictionary-to-thesaurus.py
+++ b/cs_CZ/thesaurus/dictionary-to-thesaurus.py
@@ -93,7 +93,7 @@ def parse(filename, blacklistname):
                     continue
 
                 typ = ''
-                if (len(terms) >= 2):
+                if (len(terms) >= 3):
                     typ = terms[2]
 
                     # ignore non-translations


### PR DESCRIPTION
In cs_CZ/thesaurus/dictionary-to-thesaurus.py, parse() checks len(terms) >= 2 and then reads terms[2]. For input rows with only two tab-separated columns, this can raise IndexError and stop conversion.\n\nThis patch changes the guard to len(terms) >= 3 before reading terms[2], keeping typ empty when the optional third column is missing. The converter now handles two-column rows safely.