### PR TITLE
Remove a remaining MAGIC cookie from en+GB.aff.

### DIFF
--- a/en/en_GB.aff
+++ b/en/en_GB.aff
@@ -1,4 +1,4 @@
-﻿# Affix file for British English Hunspell dictionary.
+# Affix file for British English Hunspell dictionary.
 # Furthermore, suitable as a basis for Commonwealth and European English.
 # Built from scratch for MySpell. Released under LGPL.
 #


### PR DESCRIPTION
The en_GB.aff file contains an old magic cookie "\xEF\xBB\xBF" at its beginning. This is ignored for quite a long time by hunspell. 

From affixmgr.cxx in AffixMgr::parse_file:
```
    /* remove byte order mark */
    if (firstline) {
      firstline = 0;
      // Affix file begins with byte order mark: possible incompatibility with
      // old Hunspell versions
      if (line.compare(0, 3, "\xEF\xBB\xBF", 3) == 0) {
        line.erase(0, 3);
      }
    }

```

The diff shows nothing but just removes the first 3 characters from that file...
As far as I can tell, this is the only file that still contains the byte order mark in this repo.